### PR TITLE
Fix copyJscAndroid typo in publish script

### DIFF
--- a/DemoApp/create-artifacts.cmd
+++ b/DemoApp/create-artifacts.cmd
@@ -24,7 +24,7 @@ if not exist %artifacts%\assets mkdir %artifacts%\assets
 if not exist %artifacts%\res mkdir %artifacts%\res
 
 echo %boldgreen%Publishing %boldmagenta%reactnativedemolibry%boldgreen% and copying %boldmagenta%node_modules/react-native/android%boldgreen% to maven%end%
-call ..\gradlew.bat build publish copyReactNative copyJdcAndroid
+call ..\gradlew.bat build publish copyReactNative copyJscAndroid
 
 echo %boldgreen%Creating JS bundle%end%
 call react-native bundle --platform %platform% --dev false --entry-file index.%platform%.js --bundle-output %artifacts%/assets/index.%platform%.bundle --sourcemap-output %artifacts%/assets/index.%platform%.map --assets-dest %artifacts%/res/

--- a/DemoApp/create-artifacts.sh
+++ b/DemoApp/create-artifacts.sh
@@ -23,7 +23,7 @@ mkdir -p "${artifacts}/assets"
 mkdir -p "${artifacts}/res"
 
 echo ${boldgreen}Publishing ${boldmagenta}reactnativedemolibry${boldgreen} and copying ${boldmagenta}node_modules/react-native/android${boldgreen} to maven${end}
-/bin/bash ../gradlew clean build publish copyReactNative copyJdcAndroid
+/bin/bash ../gradlew clean build publish copyReactNative copyJscAndroid
 
 echo ${boldgreen}Creating JS bundle${end}
 


### PR DESCRIPTION
Trying to bundle the RN module, I noticed this typo in the publish script. 
I only tested this on Mac myself, though. 

By the way, thanks for this great repo!